### PR TITLE
update default_title

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest_version": 2,
   "name": "Eyfo",
-  "description": "Github Package finder - Chrome extension",
+  "description": "Github Package Finder - Chrome extension",
   "version": "1.0.2",
   "browser_action": {
     "default_popup": "index.html?app",
-    "default_title": "Search Packages"
+    "default_title": "Eyfo - Github Package Finder"
   },
   "icons": {
     "16": "/assets/eyfo.png",


### PR DESCRIPTION
When the user looks for that `Eyfo` button, it is useful to show the name `Eyfo` in the extension icon tooltip, and also mention it is related to GitHub.