### PR TITLE
Don't open new tab if the current tab is empty

### DIFF
--- a/src/utils/tabUtils.js
+++ b/src/utils/tabUtils.js
@@ -1,4 +1,16 @@
 /* global window */
 export default {
-  openTab: url => window.chrome.tabs.create({ url: `https://github.com${url}` }),
+  openTab: (url) => {
+    window.chrome.tabs.query({ active: true }, (tabs) => {
+      const activeTab = tabs[0];
+      const newUrl = { url: `https://github.com${url}` };
+      if (activeTab && (activeTab.url === 'about:blank' || activeTab.url === 'about:newtab')) {
+        window.chrome.tabs.update(activeTab.id, newUrl);
+      } else {
+        window.chrome.tabs.create(newUrl);
+      }
+
+      window.close();
+    });
+  },
 };


### PR DESCRIPTION
## Motivation
Sometimes the user opens a new tab to go to some repo, and then recall she can use Eyfo to open that repo, so she opens Eyfo and selects the repo she wants. With this change, it will open the repo in the current blank tab, instead of opening a new tab.
(Tested only on Firefox)